### PR TITLE
Added prestart in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prestart": "npm install",
     "ng": "ng",
     "build": "npm run env -s && ng build --prod",
     "start": "npm run env -s && ng serve --aot --proxy-config proxy.conf.js",


### PR DESCRIPTION
Added `prestart": "npm install` in scripts. So node_modules installs with `npm start`.

One less step, you can now run the kit with just `npm start`.