### PR TITLE
Update i18n service to work in ES6

### DIFF
--- a/src/app/core/i18n.service.ts
+++ b/src/app/core/i18n.service.ts
@@ -3,8 +3,8 @@ import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 
 import { Logger } from './logger.service';
-import enUS from '../../translations/en-US.json';
-import frFR from '../../translations/fr-FR.json';
+import * as enUS from '../../translations/en-US.json';
+import * as frFR from '../../translations/fr-FR.json';
 
 const log = new Logger('I18nService');
 const languageKey = 'language';


### PR DESCRIPTION
ES6 doesn't allow anymore import without defaults like 'import * as ...'. With my Angular 8 project, I need to change the i18n adding this change.